### PR TITLE
Only count primary draft records

### DIFF
--- a/utils/wrapper.rb
+++ b/utils/wrapper.rb
@@ -13,13 +13,15 @@ class Handler < TurbotRunner::BaseHandler
   end
 
   def handle_valid_record(record, data_type)
-    if ENV['RUN_TYPE'] == "draft" && @count > MAX_DRAFT_ROWS
-      raise TurbotRunner::InterruptRun
-    else
-      @count += 1
-    end
+    if data_type == 'primary data'
+      if ENV['RUN_TYPE'] == "draft" && @count > MAX_DRAFT_ROWS
+        raise TurbotRunner::InterruptRun
+      else
+        @count += 1
+      end
 
-    STDOUT.puts "#{Time.now} :: Handled #{@count} records" if @count % 1000 == 0
+      STDOUT.puts "#{Time.now} :: Handled #{@count} records" if @count % 1000 == 0
+    end
   end
 
   def handle_invalid_record(record, data_type, errors)


### PR DESCRIPTION
Actually two commits here -- the first is a belt-and-braces check that we probably don't need (there was a race condition where we were trying to clone a repo before it was created, but that's fixed) and I can remove it if you'd like.

The second commits means that we only count the number of primary data records produced.